### PR TITLE
Fix S-I+G-N Errors's Continue Reading Section Error

### DIFF
--- a/site/src/routes/scriptures/general/sign/+page.svelte
+++ b/site/src/routes/scriptures/general/sign/+page.svelte
@@ -25,7 +25,7 @@ import ArticleArray from "#parts/page/article-array.svelte";
     <h2> Continue Reading </h2>
     
     <ArticleArray paths={[
-      "/scriptures/inequalities.md",
+      "scriptures/general/inequalities.md",
     ]} />
   </aside>
 </article>

--- a/site/src/routes/scriptures/general/sign/+page.svelte
+++ b/site/src/routes/scriptures/general/sign/+page.svelte
@@ -25,7 +25,7 @@ import ArticleArray from "#parts/page/article-array.svelte";
     <h2> Continue Reading </h2>
     
     <ArticleArray paths={[
-      "scriptures/inequalities.md",
+      "/scriptures/inequalities.md",
     ]} />
   </aside>
 </article>


### PR DESCRIPTION
Previously, it displayed a error as the path (`scriptures/inequalities.md`) was incorrect

My instance: https://syan212.github.io/integrity/scriptures/general/sign

P.S. I know one of the commits is stupid, don't blame me